### PR TITLE
Added JitPack repo and the proper diva-core dependency

### DIFF
--- a/windup/pom.xml
+++ b/windup/pom.xml
@@ -19,6 +19,13 @@
         <version.windup>LATEST</version.windup>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <!-- Windup BOM -->
@@ -36,10 +43,9 @@
 
         <!-- Diva -->
         <dependency>
-            <groupId>io.tackle</groupId>
-            <artifactId>diva-core</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <optional>true</optional>
+            <groupId>com.github.konveyor</groupId>
+            <artifactId>tackle-diva</artifactId>
+            <version>main-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- added the Jitpack registry
- declared the `diva-core` dependency following the Jitpack's naming convention

Consider Jitpack works also if the `version` tag references a commit or a tag so we can use it in a very productive way: right now it's using the snapshot version based on the latest `main` branch.