### PR TITLE
Added an entrypoint and command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ COPY distrib/ /diva-distribution/
 COPY --from=build /home/gradle/diva/bin/*.jar /diva-distribution/bin/
 COPY --from=build /home/gradle/diva/lib/*.jar /diva-distribution/lib/
 
-WORKDIR /tmp
+WORKDIR /diva-distribution/bin
+ENTRYPOINT [ "bash" ]
+CMD [ "./diva", "/app"]

--- a/distrib/bin/diva_docker
+++ b/distrib/bin/diva_docker
@@ -12,5 +12,4 @@
 
 TARGET_APP_DIRECTORY=$1
 
-docker rm -f diva 2> /dev/null || true
-docker run -v ${TARGET_APP_DIRECTORY}:/app -v ${PWD}/../output:/diva-distribution/output --name diva diva /bin/bash -c "cd /diva-distribution/bin; ./diva /app"
+docker run --rm -v ${TARGET_APP_DIRECTORY}:/app -v ${PWD}/../output:/diva-distribution/output diva


### PR DESCRIPTION
This change adds an `ENTRYPOINT` and `CMD` to the `Dockerfile` so that the Docker image runs the `diva` command by default when you invoke the container making it easier for people to use the tool.

This fixes #54 